### PR TITLE
ISICO-13908: set-output is deprecated.

### DIFF
--- a/.github/workflows/ciscom31_publish_jar.yml
+++ b/.github/workflows/ciscom31_publish_jar.yml
@@ -62,7 +62,7 @@ jobs:
           path: 'buildscan.log'
       - name: Create build tag
         run: |
-          echo "::set-output name=TAG::$(git describe --abbrev=0 --tags --exclude '*-build.*')-build.${{ github.run_number }}+${{ github.sha }}"
+          echo "TAG::$(git describe --abbrev=0 --tags --exclude '*-build.*')-build.${{ github.run_number }}+${{ github.sha }}" >> $GITHUB_OUTPUT
         id: tag
       - name: Upload conductor-server JAR
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
