### PR TITLE
ISICO-13908: gradle build required even for refs/heads/main branch and

### DIFF
--- a/.github/workflows/ciscom31_publish_jar.yml
+++ b/.github/workflows/ciscom31_publish_jar.yml
@@ -3,8 +3,7 @@ name: CiscoM31PublishJar
 on:
   push:
     branches:
-      - master
-      - commonbranch
+      - main
 
 jobs:
   build:
@@ -36,7 +35,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
       - name: Build with Gradle
-        if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
run ciscom31 publish jar only when PR is merged to main.

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
