### PR TITLE
ISCDETS-34689: redis lock added

### DIFF
--- a/community-server/build.gradle
+++ b/community-server/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation "com.cisco.conductor:conductor-rest:${revConductorCustom}"
 
     implementation "com.cisco.conductor:conductor-redis-persistence:${revConductorCustom}"
+    implementation "com.cisco.conductor:conductor-redis-lock:${revConductorCustom}"
     //implementation "com.netflix.conductor:conductor-cassandra-persistence:${revConductor}"
     //implementation "com.netflix.conductor:conductor-grpc-server:${revConductor}"
     //implementation "com.netflix.conductor:conductor-redis-lock:${revConductor}"


### PR DESCRIPTION
redis-lock is included to avoid multiple scheduling of same task.

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
