### PR TITLE
MINERVA-2937: tomcat jar upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:10.0.0'
-        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.7.16'
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.7.18'
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.+'
     }
 }

--- a/community-server/dependencies.lock
+++ b/community-server/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -93,19 +93,19 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -482,10 +482,10 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
             "firstLevelTransitive": [
@@ -493,16 +493,16 @@
                 "com.netflix.conductor:conductor-postgres-external-storage",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -879,10 +879,10 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
             "firstLevelTransitive": [
@@ -890,16 +890,16 @@
                 "com.netflix.conductor:conductor-postgres-external-storage",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -1015,22 +1015,22 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -1425,10 +1425,10 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
             "firstLevelTransitive": [
@@ -1436,19 +1436,19 @@
                 "com.netflix.conductor:conductor-postgres-external-storage",
                 "com.netflix.conductor:conductor-postgres-persistence"
             ],
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -71,10 +71,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testRuntimeClasspath": {
@@ -100,10 +100,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     }
 }

--- a/dir
+++ b/dir
@@ -1,0 +1,2213 @@
+
+> Configure project :
+Inferred project: conductor-community, version: 3.16.0-SNAPSHOT
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+Unable to convert https://github.com/CiscoM31/conductor-community to https form in MavenScmPlugin. Using original value.
+
+> Task :conductor-community-server:dependencies
+
+------------------------------------------------------------
+Project ':conductor-community-server' - conductor-community-server
+------------------------------------------------------------
+
+annotationProcessor - Annotation processors and their dependencies for source set 'main'.
+\--- org.springframework.boot:spring-boot-configuration-processor -> 2.7.18
+
+api - API dependencies for source set 'main'. (n)
+No dependencies
+
+apiElements - API elements for main. (n)
+No dependencies
+
+archives - Configuration for archive artifacts. (n)
+No dependencies
+
+bootArchives - Configuration for Spring Boot archive artifacts. (n)
+No dependencies
+
+compileClasspath - Compile classpath for source set 'main'.
++--- org.apache.logging.log4j:log4j-core -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-api -> 2.17.2
++--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2
+|    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.36
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-jul -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-web -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    \--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
++--- com.cisco.conductor:conductor-core:3.15.0-cisco
++--- com.cisco.conductor:conductor-rest:3.15.0-cisco
++--- com.cisco.conductor:conductor-redis-persistence:3.15.0-cisco
++--- project :conductor-metrics
++--- project :conductor-workflow-event-listener
++--- project :task-event-listener
++--- project :common
++--- org.springframework.boot:spring-boot-starter -> 2.7.18
+|    +--- org.springframework.boot:spring-boot:2.7.18
+|    |    +--- org.springframework:spring-core:5.3.31
+|    |    |    \--- org.springframework:spring-jcl:5.3.31
+|    |    \--- org.springframework:spring-context:5.3.31
+|    |         +--- org.springframework:spring-aop:5.3.31
+|    |         |    +--- org.springframework:spring-beans:5.3.31
+|    |         |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |         |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |         +--- org.springframework:spring-beans:5.3.31 (*)
+|    |         +--- org.springframework:spring-core:5.3.31 (*)
+|    |         \--- org.springframework:spring-expression:5.3.31
+|    |              \--- org.springframework:spring-core:5.3.31 (*)
+|    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.18
+|    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-starter-logging:2.7.18
+|    |    \--- org.slf4j:jul-to-slf4j:1.7.36
+|    |         \--- org.slf4j:slf4j-api:1.7.36
+|    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    +--- org.springframework:spring-core:5.3.31 (*)
+|    \--- org.yaml:snakeyaml:1.30 -> 2.0
++--- org.springframework.boot:spring-boot-starter-validation -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    \--- org.hibernate.validator:hibernate-validator:6.2.5.Final
+|         +--- jakarta.validation:jakarta.validation-api:2.0.2
+|         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
+|         \--- com.fasterxml:classmate:1.5.1
++--- org.springframework.boot:spring-boot-starter-web -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-starter-json:2.7.18
+|    |    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    |    +--- org.springframework:spring-web:5.3.31
+|    |    |    +--- org.springframework:spring-beans:5.3.31 (*)
+|    |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5 (c)
+|    |    |    |         \--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.5 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5
+|    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |         \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- org.springframework.boot:spring-boot-starter-tomcat:2.7.18
+|    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    |    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.83
+|    |         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    +--- org.springframework:spring-web:5.3.31 (*)
+|    \--- org.springframework:spring-webmvc:5.3.31
+|         +--- org.springframework:spring-aop:5.3.31 (*)
+|         +--- org.springframework:spring-beans:5.3.31 (*)
+|         +--- org.springframework:spring-context:5.3.31 (*)
+|         +--- org.springframework:spring-core:5.3.31 (*)
+|         +--- org.springframework:spring-expression:5.3.31 (*)
+|         \--- org.springframework:spring-web:5.3.31 (*)
++--- org.springframework.retry:spring-retry -> 1.3.4
++--- org.springframework.boot:spring-boot-starter-log4j2 -> 2.7.18
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    \--- org.slf4j:jul-to-slf4j:1.7.36 (*)
++--- org.springframework.boot:spring-boot-starter-actuator -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:2.7.18
+|    |    +--- org.springframework.boot:spring-boot-actuator:2.7.18
+|    |    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    +--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    \--- org.springframework.boot:spring-boot-autoconfigure:2.7.18 (*)
+|    \--- io.micrometer:micrometer-core:1.9.17
+|         \--- org.hdrhistogram:HdrHistogram:2.1.12
++--- org.springdoc:springdoc-openapi-ui:1.6.+ -> 1.6.15
+|    +--- org.springdoc:springdoc-openapi-webmvc-core:1.6.15
+|    |    +--- org.springdoc:springdoc-openapi-common:1.6.15
+|    |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.9 -> 2.7.18 (*)
+|    |    |    +--- org.springframework:spring-web:5.3.25 -> 5.3.31 (*)
+|    |    |    \--- io.swagger.core.v3:swagger-core:2.2.8
+|    |    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2 -> 2.3.3
+|    |    |         |    \--- jakarta.activation:jakarta.activation-api:1.2.2
+|    |    |         +--- org.apache.commons:commons-lang3:3.12.0
+|    |    |         +--- org.slf4j:slf4j-api:1.7.35 -> 1.7.36
+|    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.14.0 -> 2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0 -> 2.13.5
+|    |    |         |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |         |    +--- org.yaml:snakeyaml:1.31 -> 2.0
+|    |    |         |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |         |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0 -> 2.13.5 (*)
+|    |    |         +--- io.swagger.core.v3:swagger-annotations:2.2.8
+|    |    |         +--- org.yaml:snakeyaml:1.33 -> 2.0
+|    |    |         +--- io.swagger.core.v3:swagger-models:2.2.8
+|    |    |         |    \--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|    |    |         \--- jakarta.validation:jakarta.validation-api:2.0.2
+|    |    \--- org.springframework:spring-webmvc:5.3.25 -> 5.3.31 (*)
+|    +--- org.webjars:swagger-ui:4.17.1
+|    +--- org.webjars:webjars-locator-core:0.52 -> 0.50
+|    |    +--- org.slf4j:slf4j-api:1.7.36
+|    |    \--- com.fasterxml.jackson.core:jackson-core:2.13.1 -> 2.13.5 (*)
+|    \--- io.github.classgraph:classgraph:4.8.149
+\--- com.cisco.conductor:conductor-common:3.15.0-cisco
+
+compileOnly - Compile only dependencies for source set 'main'. (n)
+No dependencies
+
+compileOnlyApi - Compile only API dependencies for source set 'main'. (n)
+No dependencies
+
+default - Configuration for default artifacts. (n)
+No dependencies
+
+developmentOnly - Configuration for development-only dependencies such as Spring Boot's DevTools.
+No dependencies
+
+implementation - Implementation only dependencies for source set 'main'. (n)
++--- org.apache.logging.log4j:log4j-core (n)
++--- org.apache.logging.log4j:log4j-api (n)
++--- org.apache.logging.log4j:log4j-slf4j-impl (n)
++--- org.apache.logging.log4j:log4j-jul (n)
++--- org.apache.logging.log4j:log4j-web (n)
++--- com.cisco.conductor:conductor-core:3.15.0-cisco (n)
++--- com.cisco.conductor:conductor-rest:3.15.0-cisco (n)
++--- com.cisco.conductor:conductor-redis-persistence:3.15.0-cisco (n)
++--- project conductor-metrics (n)
++--- project conductor-workflow-event-listener (n)
++--- project task-event-listener (n)
++--- project common (n)
++--- org.springframework.boot:spring-boot-starter (n)
++--- org.springframework.boot:spring-boot-starter-validation (n)
++--- org.springframework.boot:spring-boot-starter-web (n)
++--- org.springframework.retry:spring-retry (n)
++--- org.springframework.boot:spring-boot-starter-log4j2 (n)
++--- org.springframework.boot:spring-boot-starter-actuator (n)
++--- org.springdoc:springdoc-openapi-ui:1.6.+ (n)
+\--- com.cisco.conductor:conductor-common:3.15.0-cisco (n)
+
+javadocElements - javadoc elements for main. (n)
+No dependencies
+
+mainSourceElements - List of source directories contained in the Main SourceSet. (n)
+No dependencies
+
+productionRuntimeClasspath
++--- org.apache.logging.log4j:log4j-core -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-api -> 2.17.2
++--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2
+|    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.36
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    \--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
++--- org.apache.logging.log4j:log4j-jul -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-web -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    \--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
++--- com.cisco.conductor:conductor-core:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5
+|    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.module:jackson-module-afterburner:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.5 (c)
+|    |         \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5 (c)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- org.yaml:snakeyaml:1.31 -> 2.0
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- joda-time:joda-time:2.10.8
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:1.2.2
+|    |    |    +--- jakarta.activation:jakarta.activation-api:1.2.1 -> 1.2.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco
+|    |    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    |    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    |    +--- com.netflix.conductor:conductor-annotations:3.15.0-cisco -> 3.15.0
+|    |    |    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    |    |    \--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    |    +--- org.apache.commons:commons-lang3:3.12.0
+|    |    +--- org.apache.bval:bval-jsr:2.0.6
+|    |    +--- com.google.protobuf:protobuf-java:3.24.3
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.15.0 -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.15.0 -> 2.13.5 (*)
+|    |    \--- com.fasterxml.jackson.module:jackson-module-afterburner:2.15.0 -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:2.15.0 -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.15.0 -> 2.13.5 (*)
+|    +--- commons-io:commons-io:2.7
+|    +--- com.google.protobuf:protobuf-java:3.24.3
+|    +--- org.apache.commons:commons-lang3:3.12.0
+|    +--- com.fasterxml.jackson.core:jackson-core:2.15.0 -> 2.13.5 (*)
+|    +--- com.spotify:completable-futures:0.3.3
+|    +--- com.jayway.jsonpath:json-path:2.4.0 -> 2.7.0
+|    |    +--- net.minidev:json-smart:2.4.7 -> 2.4.11
+|    |    |    \--- net.minidev:accessors-smart:2.4.11
+|    |    |         \--- org.ow2.asm:asm:9.3
+|    |    \--- org.slf4j:slf4j-api:1.7.33 -> 1.7.36
+|    +--- io.reactivex:rxjava:1.2.2 -> 1.3.8
+|    +--- com.netflix.spectator:spectator-api:0.122.0
+|    |    \--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    +--- org.apache.bval:bval-jsr:2.0.6
+|    +--- com.github.ben-manes.caffeine:caffeine:2.9.3
+|    |    +--- org.checkerframework:checker-qual:3.19.0 -> 3.33.0
+|    |    \--- com.google.errorprone:error_prone_annotations:2.10.0 -> 2.18.0
+|    +--- org.openjdk.nashorn:nashorn-core:15.4
+|    |    +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    +--- org.ow2.asm:asm-commons:7.3.1
+|    |    |    +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    |    +--- org.ow2.asm:asm-tree:7.3.1
+|    |    |    |    \--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    |    \--- org.ow2.asm:asm-analysis:7.3.1
+|    |    |         \--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |    +--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |    \--- org.ow2.asm:asm-util:7.3.1
+|    |         +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |         +--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |         \--- org.ow2.asm:asm-analysis:7.3.1 (*)
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (*)
+|    \--- jakarta.activation:jakarta.activation-api:2.0.0 -> 1.2.2
++--- com.cisco.conductor:conductor-rest:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- org.springframework.boot:spring-boot-starter-web:2.7.18
+|    |    +--- org.springframework.boot:spring-boot-starter:2.7.18
+|    |    |    +--- org.springframework.boot:spring-boot:2.7.18
+|    |    |    |    +--- org.springframework:spring-core:5.3.31
+|    |    |    |    |    \--- org.springframework:spring-jcl:5.3.31
+|    |    |    |    \--- org.springframework:spring-context:5.3.31
+|    |    |    |         +--- org.springframework:spring-aop:5.3.31
+|    |    |    |         |    +--- org.springframework:spring-beans:5.3.31
+|    |    |    |         |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         +--- org.springframework:spring-beans:5.3.31 (*)
+|    |    |    |         +--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         \--- org.springframework:spring-expression:5.3.31
+|    |    |    |              \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.18
+|    |    |    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    |    +--- org.springframework.boot:spring-boot-starter-logging:2.7.18
+|    |    |    |    \--- org.slf4j:jul-to-slf4j:1.7.36
+|    |    |    |         \--- org.slf4j:slf4j-api:1.7.36
+|    |    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    |    |    +--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    \--- org.yaml:snakeyaml:1.30 -> 2.0
+|    |    +--- org.springframework.boot:spring-boot-starter-json:2.7.18
+|    |    |    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    |    |    +--- org.springframework:spring-web:5.3.31
+|    |    |    |    +--- org.springframework:spring-beans:5.3.31 (*)
+|    |    |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5
+|    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |         \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- org.springframework.boot:spring-boot-starter-tomcat:2.7.18
+|    |    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    |    |    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    |    |    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    |    |    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.83
+|    |    |         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    |    +--- org.springframework:spring-web:5.3.31 (*)
+|    |    \--- org.springframework:spring-webmvc:5.3.31
+|    |         +--- org.springframework:spring-aop:5.3.31 (*)
+|    |         +--- org.springframework:spring-beans:5.3.31 (*)
+|    |         +--- org.springframework:spring-context:5.3.31 (*)
+|    |         +--- org.springframework:spring-core:5.3.31 (*)
+|    |         +--- org.springframework:spring-expression:5.3.31 (*)
+|    |         \--- org.springframework:spring-web:5.3.31 (*)
+|    +--- com.netflix.runtime:health-api:1.1.4
+|    \--- org.springdoc:springdoc-openapi-ui:1.6.15
+|         +--- org.springdoc:springdoc-openapi-webmvc-core:1.6.15
+|         |    +--- org.springdoc:springdoc-openapi-common:1.6.15
+|         |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.9 -> 2.7.18 (*)
+|         |    |    +--- org.springframework:spring-web:5.3.25 -> 5.3.31 (*)
+|         |    |    \--- io.swagger.core.v3:swagger-core:2.2.8
+|         |    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2 -> 2.3.3 (*)
+|         |    |         +--- org.apache.commons:commons-lang3:3.12.0
+|         |    |         +--- org.slf4j:slf4j-api:1.7.35 -> 1.7.36
+|         |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- io.swagger.core.v3:swagger-annotations:2.2.8
+|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.0
+|         |    |         +--- io.swagger.core.v3:swagger-models:2.2.8
+|         |    |         |    \--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|         |    |         \--- jakarta.validation:jakarta.validation-api:2.0.2
+|         |    \--- org.springframework:spring-webmvc:5.3.25 -> 5.3.31 (*)
+|         +--- org.webjars:swagger-ui:4.17.1
+|         +--- org.webjars:webjars-locator-core:0.52 -> 0.50
+|         |    +--- org.slf4j:slf4j-api:1.7.36
+|         |    \--- com.fasterxml.jackson.core:jackson-core:2.13.1 -> 2.13.5 (*)
+|         \--- io.github.classgraph:classgraph:4.8.149
++--- com.cisco.conductor:conductor-redis-persistence:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- redis.clients:jedis:3.3.0 -> 3.8.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    \--- org.apache.commons:commons-pool2:2.11.1
+|    +--- com.netflix.dyno-queues:dyno-queues-redis:2.0.20
+|    |    +--- com.netflix.dyno-queues:dyno-queues-core:2.0.20
+|    |    |    \--- com.netflix.dyno:dyno-core:1.7.2-rc2
+|    |    |         +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |         +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |         +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |         +--- org.apache.httpcomponents:httpclient:4.2.1 -> 4.5.14
+|    |    |         |    +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |    |         |    +--- commons-logging:commons-logging:1.2
+|    |    |         |    \--- commons-codec:commons-codec:1.11 -> 1.15
+|    |    |         +--- com.sun.jersey:jersey-core:1.11 -> 1.19.1
+|    |    |         |    \--- javax.ws.rs:jsr311-api:1.1.1
+|    |    |         +--- org.apache.commons:commons-math:2.2
+|    |    |         +--- org.apache.commons:commons-lang3:3.6 -> 3.12.0
+|    |    |         \--- commons-io:commons-io:2.4 -> 2.7
+|    |    +--- com.google.inject:guice:4.1.0
+|    |    |    +--- javax.inject:javax.inject:1
+|    |    |    +--- aopalliance:aopalliance:1.0
+|    |    |    \--- com.google.guava:guava:19.0 -> 32.1.2-jre
+|    |    |         +--- com.google.guava:guava-parent:32.1.2-jre
+|    |    |         |    +--- com.google.code.findbugs:jsr305:3.0.2 (c)
+|    |    |         |    +--- org.checkerframework:checker-qual:3.33.0 (c)
+|    |    |         |    \--- com.google.errorprone:error_prone_annotations:2.18.0 (c)
+|    |    |         +--- com.google.guava:failureaccess:1.0.1
+|    |    |         +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |    |         +--- com.google.code.findbugs:jsr305 -> 3.0.2
+|    |    |         +--- org.checkerframework:checker-qual -> 3.33.0
+|    |    |         \--- com.google.errorprone:error_prone_annotations -> 2.18.0
+|    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2
+|    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-contrib:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    +--- com.google.inject:guice:4.1.0 (*)
+|    |    |    |    +--- com.netflix.archaius:archaius-core:0.7.6
+|    |    |    |    |    +--- com.google.code.findbugs:jsr305:3.0.1 -> 3.0.2
+|    |    |    |    |    +--- commons-configuration:commons-configuration:1.8
+|    |    |    |    |    |    +--- commons-lang:commons-lang:2.6
+|    |    |    |    |    |    \--- commons-logging:commons-logging:1.1.1 -> 1.2
+|    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    +--- com.google.guava:guava:16.0 -> 32.1.2-jre (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.4.3 -> 2.13.5 (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.4.3 -> 2.13.5 (*)
+|    |    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.4.3 -> 2.13.5 (*)
+|    |    |    |    +--- com.netflix.servo:servo-core:0.12.17
+|    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    |    \--- com.google.guava:guava:19.0 -> 32.1.2-jre (*)
+|    |    |    |    +--- com.netflix.eureka:eureka-client:1.8.6
+|    |    |    |    |    +--- org.codehaus.jettison:jettison:1.3.7
+|    |    |    |    |    |    \--- stax:stax-api:1.0.1
+|    |    |    |    |    +--- com.netflix.netflix-commons:netflix-eventbus:0.3.0
+|    |    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    |    +--- com.netflix.netflix-commons:netflix-infix:0.3.0
+|    |    |    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    |    |    +--- commons-jxpath:commons-jxpath:1.3
+|    |    |    |    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    |    |    |    +--- javax.servlet:servlet-api:2.5
+|    |    |    |    |    |    |    +--- org.antlr:antlr-runtime:3.4
+|    |    |    |    |    |    |    |    +--- org.antlr:stringtemplate:3.2.1
+|    |    |    |    |    |    |    |    |    \--- antlr:antlr:2.7.7
+|    |    |    |    |    |    |    |    \--- antlr:antlr:2.7.7
+|    |    |    |    |    |    |    +--- com.google.code.findbugs:jsr305:3.0.1 -> 3.0.2
+|    |    |    |    |    |    |    +--- com.google.guava:guava:14.0.1 -> 32.1.2-jre (*)
+|    |    |    |    |    |    |    \--- com.google.code.gson:gson:2.1 -> 2.9.1
+|    |    |    |    |    |    +--- com.netflix.servo:servo-core:0.5.3 -> 0.12.17 (*)
+|    |    |    |    |    |    +--- com.netflix.archaius:archaius-core:0.3.3 -> 0.7.6 (*)
+|    |    |    |    |    |    \--- org.apache.commons:commons-math:2.2
+|    |    |    |    |    +--- com.thoughtworks.xstream:xstream:1.4.10 -> 1.4.20
+|    |    |    |    |    |    \--- io.github.x-stream:mxparser:1.2.2
+|    |    |    |    |    |         \--- xmlpull:xmlpull:1.1.3.1
+|    |    |    |    |    +--- com.netflix.archaius:archaius-core:0.7.5 -> 0.7.6 (*)
+|    |    |    |    |    +--- javax.ws.rs:jsr311-api:1.1.1
+|    |    |    |    |    +--- com.netflix.servo:servo-core:0.10.1 -> 0.12.17 (*)
+|    |    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    |    +--- com.sun.jersey:jersey-client:1.19.1
+|    |    |    |    |    |    \--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    |    +--- com.sun.jersey.contribs:jersey-apache-client4:1.19.1
+|    |    |    |    |    |    +--- org.apache.httpcomponents:httpclient:4.1.1 -> 4.5.14 (*)
+|    |    |    |    |    |    \--- com.sun.jersey:jersey-client:1.19.1 (*)
+|    |    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    |    +--- com.google.inject:guice:4.1.0 (*)
+|    |    |    |    |    +--- com.github.vlsi.compactmap:compactmap:1.2.1
+|    |    |    |    |    |    \--- com.github.andrewoma.dexx:dexx-collections:0.2
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.8.7 -> 2.13.5 (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.8.7 -> 2.13.5 (*)
+|    |    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.8.7 -> 2.13.5 (*)
+|    |    |    |    +--- org.apache.commons:commons-lang3:3.6 -> 3.12.0
+|    |    |    |    \--- com.ecwid.consul:consul-api:1.2.1
+|    |    |    |         \--- com.google.code.gson:gson:2.3 -> 2.9.1
+|    |    |    +--- redis.clients:jedis:3.0.1 -> 3.8.0 (*)
+|    |    |    \--- org.projectlombok:lombok:1.18.4 -> 1.18.30
+|    |    +--- com.netflix.dyno:dyno-demo:1.7.2-rc2
+|    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-contrib:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-memcache:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    \--- com.netflix.dyno:dyno-contrib:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-recipes:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2 (*)
+|    |    |    |    \--- com.google.code.gson:gson:2.8.5 -> 2.9.1
+|    |    |    \--- commons-cli:commons-cli:1.4
+|    |    +--- com.netflix.archaius:archaius-core:0.7.6 (*)
+|    |    +--- com.netflix.servo:servo-core:0.12.17 (*)
+|    |    +--- com.netflix.eureka:eureka-client:1.8.6 (*)
+|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.8.7 -> 2.13.5 (*)
+|    +--- com.thoughtworks.xstream:xstream:1.4.20 (*)
+|    \--- org.rarefiedredis.redis:redis-java:0.0.17
+|         +--- redis.clients:jedis:2.6.2 -> 3.8.0 (*)
+|         \--- org.luaj:luaj-jse:3.0
++--- project :conductor-metrics
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- org.apache.commons:commons-lang3 -> 3.12.0
+|    +--- com.google.guava:guava:32.1.2-jre (*)
+|    +--- javax.ws.rs:jsr311-api:1.1.1
+|    +--- io.reactivex:rxjava:1.2.2 -> 1.3.8
+|    +--- com.netflix.spectator:spectator-reg-metrics3:0.122.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    +--- com.netflix.spectator:spectator-api:0.122.0 (*)
+|    |    \--- io.dropwizard.metrics:metrics-core:3.1.2 -> 4.2.22
+|    |         \--- org.slf4j:slf4j-api:1.7.36
+|    +--- com.netflix.spectator:spectator-reg-micrometer:0.122.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    +--- io.micrometer:micrometer-core:1.6.1 -> 1.9.17
+|    |    |    +--- org.hdrhistogram:HdrHistogram:2.1.12
+|    |    |    \--- org.latencyutils:LatencyUtils:2.0.3
+|    |    \--- com.netflix.spectator:spectator-api:0.122.0 (*)
+|    +--- io.prometheus:simpleclient:0.9.0 -> 0.15.0
+|    |    +--- io.prometheus:simpleclient_tracer_otel:0.15.0
+|    |    |    \--- io.prometheus:simpleclient_tracer_common:0.15.0
+|    |    \--- io.prometheus:simpleclient_tracer_otel_agent:0.15.0
+|    |         \--- io.prometheus:simpleclient_tracer_common:0.15.0
+|    +--- io.micrometer:micrometer-registry-prometheus:1.6.2 -> 1.9.15
+|    |    +--- io.micrometer:micrometer-core:1.9.15 -> 1.9.17 (*)
+|    |    \--- io.prometheus:simpleclient_common:0.15.0
+|    |         \--- io.prometheus:simpleclient:0.15.0 (*)
+|    \--- io.micrometer:micrometer-registry-datadog:1.9.1 -> 1.9.15
+|         +--- io.micrometer:micrometer-core:1.9.15 -> 1.9.17 (*)
+|         \--- org.slf4j:slf4j-api:1.7.36
++--- project :conductor-workflow-event-listener
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- javax.inject:javax.inject:1
+|    +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|    \--- project :common
+|         +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|         +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|         +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|         +--- javax.inject:javax.inject:1
+|         +--- org.apache.commons:commons-lang3 -> 3.12.0
+|         \--- org.apache.httpcomponents:httpclient:4.5.14 (*)
++--- project :task-event-listener
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- project :common (*)
+|    +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|    +--- javax.inject:javax.inject:1
+|    +--- org.apache.commons:commons-lang3 -> 3.12.0
+|    \--- org.apache.httpcomponents:httpclient:4.5.14 (*)
++--- project :common (*)
++--- org.springframework.boot:spring-boot-starter -> 2.7.18 (*)
++--- org.springframework.boot:spring-boot-starter-validation -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    \--- org.hibernate.validator:hibernate-validator:6.2.5.Final
+|         +--- jakarta.validation:jakarta.validation-api:2.0.2
+|         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
+|         \--- com.fasterxml:classmate:1.5.1
++--- org.springframework.boot:spring-boot-starter-web -> 2.7.18 (*)
++--- org.springframework.retry:spring-retry -> 1.3.4
++--- org.springframework.boot:spring-boot-starter-log4j2 -> 2.7.18
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    \--- org.slf4j:jul-to-slf4j:1.7.36 (*)
++--- org.springframework.boot:spring-boot-starter-actuator -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:2.7.18
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (*)
+|    |    +--- org.springframework.boot:spring-boot-actuator:2.7.18
+|    |    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    +--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    \--- org.springframework.boot:spring-boot-autoconfigure:2.7.18 (*)
+|    \--- io.micrometer:micrometer-core:1.9.17 (*)
++--- org.springdoc:springdoc-openapi-ui:1.6.+ -> 1.6.15 (*)
++--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+\--- org.glassfish.jaxb:jaxb-runtime:2.3.3
+     +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (*)
+     +--- org.glassfish.jaxb:txw2:2.3.3 -> 2.3.9
+     +--- com.sun.istack:istack-commons-runtime:3.0.11
+     \--- com.sun.activation:jakarta.activation:1.2.2
+
+runtimeClasspath - Runtime classpath of source set 'main'.
++--- org.apache.logging.log4j:log4j-core -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-api -> 2.17.2
++--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2
+|    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.36
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    \--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
++--- org.apache.logging.log4j:log4j-jul -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-web -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    \--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
++--- com.cisco.conductor:conductor-core:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5
+|    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.module:jackson-module-afterburner:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.5 (c)
+|    |         \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5 (c)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- org.yaml:snakeyaml:1.31 -> 2.0
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- joda-time:joda-time:2.10.8
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:1.2.2
+|    |    |    +--- jakarta.activation:jakarta.activation-api:1.2.1 -> 1.2.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco
+|    |    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    |    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    |    +--- com.netflix.conductor:conductor-annotations:3.15.0-cisco -> 3.15.0
+|    |    |    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    |    |    \--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    |    +--- org.apache.commons:commons-lang3:3.12.0
+|    |    +--- org.apache.bval:bval-jsr:2.0.6
+|    |    +--- com.google.protobuf:protobuf-java:3.24.3
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.15.0 -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.15.0 -> 2.13.5 (*)
+|    |    \--- com.fasterxml.jackson.module:jackson-module-afterburner:2.15.0 -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:2.15.0 -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.15.0 -> 2.13.5 (*)
+|    +--- commons-io:commons-io:2.7
+|    +--- com.google.protobuf:protobuf-java:3.24.3
+|    +--- org.apache.commons:commons-lang3:3.12.0
+|    +--- com.fasterxml.jackson.core:jackson-core:2.15.0 -> 2.13.5 (*)
+|    +--- com.spotify:completable-futures:0.3.3
+|    +--- com.jayway.jsonpath:json-path:2.4.0 -> 2.7.0
+|    |    +--- net.minidev:json-smart:2.4.7 -> 2.4.11
+|    |    |    \--- net.minidev:accessors-smart:2.4.11
+|    |    |         \--- org.ow2.asm:asm:9.3
+|    |    \--- org.slf4j:slf4j-api:1.7.33 -> 1.7.36
+|    +--- io.reactivex:rxjava:1.2.2 -> 1.3.8
+|    +--- com.netflix.spectator:spectator-api:0.122.0
+|    |    \--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    +--- org.apache.bval:bval-jsr:2.0.6
+|    +--- com.github.ben-manes.caffeine:caffeine:2.9.3
+|    |    +--- org.checkerframework:checker-qual:3.19.0 -> 3.33.0
+|    |    \--- com.google.errorprone:error_prone_annotations:2.10.0 -> 2.18.0
+|    +--- org.openjdk.nashorn:nashorn-core:15.4
+|    |    +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    +--- org.ow2.asm:asm-commons:7.3.1
+|    |    |    +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    |    +--- org.ow2.asm:asm-tree:7.3.1
+|    |    |    |    \--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    |    \--- org.ow2.asm:asm-analysis:7.3.1
+|    |    |         \--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |    +--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |    \--- org.ow2.asm:asm-util:7.3.1
+|    |         +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |         +--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |         \--- org.ow2.asm:asm-analysis:7.3.1 (*)
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (*)
+|    \--- jakarta.activation:jakarta.activation-api:2.0.0 -> 1.2.2
++--- com.cisco.conductor:conductor-rest:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- org.springframework.boot:spring-boot-starter-web:2.7.18
+|    |    +--- org.springframework.boot:spring-boot-starter:2.7.18
+|    |    |    +--- org.springframework.boot:spring-boot:2.7.18
+|    |    |    |    +--- org.springframework:spring-core:5.3.31
+|    |    |    |    |    \--- org.springframework:spring-jcl:5.3.31
+|    |    |    |    \--- org.springframework:spring-context:5.3.31
+|    |    |    |         +--- org.springframework:spring-aop:5.3.31
+|    |    |    |         |    +--- org.springframework:spring-beans:5.3.31
+|    |    |    |         |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         +--- org.springframework:spring-beans:5.3.31 (*)
+|    |    |    |         +--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         \--- org.springframework:spring-expression:5.3.31
+|    |    |    |              \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.18
+|    |    |    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    |    +--- org.springframework.boot:spring-boot-starter-logging:2.7.18
+|    |    |    |    \--- org.slf4j:jul-to-slf4j:1.7.36
+|    |    |    |         \--- org.slf4j:slf4j-api:1.7.36
+|    |    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    |    |    +--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    \--- org.yaml:snakeyaml:1.30 -> 2.0
+|    |    +--- org.springframework.boot:spring-boot-starter-json:2.7.18
+|    |    |    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    |    |    +--- org.springframework:spring-web:5.3.31
+|    |    |    |    +--- org.springframework:spring-beans:5.3.31 (*)
+|    |    |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5
+|    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |         \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- org.springframework.boot:spring-boot-starter-tomcat:2.7.18
+|    |    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    |    |    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    |    |    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    |    |    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.83
+|    |    |         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    |    +--- org.springframework:spring-web:5.3.31 (*)
+|    |    \--- org.springframework:spring-webmvc:5.3.31
+|    |         +--- org.springframework:spring-aop:5.3.31 (*)
+|    |         +--- org.springframework:spring-beans:5.3.31 (*)
+|    |         +--- org.springframework:spring-context:5.3.31 (*)
+|    |         +--- org.springframework:spring-core:5.3.31 (*)
+|    |         +--- org.springframework:spring-expression:5.3.31 (*)
+|    |         \--- org.springframework:spring-web:5.3.31 (*)
+|    +--- com.netflix.runtime:health-api:1.1.4
+|    \--- org.springdoc:springdoc-openapi-ui:1.6.15
+|         +--- org.springdoc:springdoc-openapi-webmvc-core:1.6.15
+|         |    +--- org.springdoc:springdoc-openapi-common:1.6.15
+|         |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.9 -> 2.7.18 (*)
+|         |    |    +--- org.springframework:spring-web:5.3.25 -> 5.3.31 (*)
+|         |    |    \--- io.swagger.core.v3:swagger-core:2.2.8
+|         |    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2 -> 2.3.3 (*)
+|         |    |         +--- org.apache.commons:commons-lang3:3.12.0
+|         |    |         +--- org.slf4j:slf4j-api:1.7.35 -> 1.7.36
+|         |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- io.swagger.core.v3:swagger-annotations:2.2.8
+|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.0
+|         |    |         +--- io.swagger.core.v3:swagger-models:2.2.8
+|         |    |         |    \--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|         |    |         \--- jakarta.validation:jakarta.validation-api:2.0.2
+|         |    \--- org.springframework:spring-webmvc:5.3.25 -> 5.3.31 (*)
+|         +--- org.webjars:swagger-ui:4.17.1
+|         +--- org.webjars:webjars-locator-core:0.52 -> 0.50
+|         |    +--- org.slf4j:slf4j-api:1.7.36
+|         |    \--- com.fasterxml.jackson.core:jackson-core:2.13.1 -> 2.13.5 (*)
+|         \--- io.github.classgraph:classgraph:4.8.149
++--- com.cisco.conductor:conductor-redis-persistence:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- redis.clients:jedis:3.3.0 -> 3.8.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    \--- org.apache.commons:commons-pool2:2.11.1
+|    +--- com.netflix.dyno-queues:dyno-queues-redis:2.0.20
+|    |    +--- com.netflix.dyno-queues:dyno-queues-core:2.0.20
+|    |    |    \--- com.netflix.dyno:dyno-core:1.7.2-rc2
+|    |    |         +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |         +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |         +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |         +--- org.apache.httpcomponents:httpclient:4.2.1 -> 4.5.14
+|    |    |         |    +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |    |         |    +--- commons-logging:commons-logging:1.2
+|    |    |         |    \--- commons-codec:commons-codec:1.11 -> 1.15
+|    |    |         +--- com.sun.jersey:jersey-core:1.11 -> 1.19.1
+|    |    |         |    \--- javax.ws.rs:jsr311-api:1.1.1
+|    |    |         +--- org.apache.commons:commons-math:2.2
+|    |    |         +--- org.apache.commons:commons-lang3:3.6 -> 3.12.0
+|    |    |         \--- commons-io:commons-io:2.4 -> 2.7
+|    |    +--- com.google.inject:guice:4.1.0
+|    |    |    +--- javax.inject:javax.inject:1
+|    |    |    +--- aopalliance:aopalliance:1.0
+|    |    |    \--- com.google.guava:guava:19.0 -> 32.1.2-jre
+|    |    |         +--- com.google.guava:guava-parent:32.1.2-jre
+|    |    |         |    +--- com.google.code.findbugs:jsr305:3.0.2 (c)
+|    |    |         |    +--- org.checkerframework:checker-qual:3.33.0 (c)
+|    |    |         |    \--- com.google.errorprone:error_prone_annotations:2.18.0 (c)
+|    |    |         +--- com.google.guava:failureaccess:1.0.1
+|    |    |         +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |    |         +--- com.google.code.findbugs:jsr305 -> 3.0.2
+|    |    |         +--- org.checkerframework:checker-qual -> 3.33.0
+|    |    |         \--- com.google.errorprone:error_prone_annotations -> 2.18.0
+|    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2
+|    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-contrib:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    +--- com.google.inject:guice:4.1.0 (*)
+|    |    |    |    +--- com.netflix.archaius:archaius-core:0.7.6
+|    |    |    |    |    +--- com.google.code.findbugs:jsr305:3.0.1 -> 3.0.2
+|    |    |    |    |    +--- commons-configuration:commons-configuration:1.8
+|    |    |    |    |    |    +--- commons-lang:commons-lang:2.6
+|    |    |    |    |    |    \--- commons-logging:commons-logging:1.1.1 -> 1.2
+|    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    +--- com.google.guava:guava:16.0 -> 32.1.2-jre (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.4.3 -> 2.13.5 (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.4.3 -> 2.13.5 (*)
+|    |    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.4.3 -> 2.13.5 (*)
+|    |    |    |    +--- com.netflix.servo:servo-core:0.12.17
+|    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    |    \--- com.google.guava:guava:19.0 -> 32.1.2-jre (*)
+|    |    |    |    +--- com.netflix.eureka:eureka-client:1.8.6
+|    |    |    |    |    +--- org.codehaus.jettison:jettison:1.3.7
+|    |    |    |    |    |    \--- stax:stax-api:1.0.1
+|    |    |    |    |    +--- com.netflix.netflix-commons:netflix-eventbus:0.3.0
+|    |    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    |    +--- com.netflix.netflix-commons:netflix-infix:0.3.0
+|    |    |    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    |    |    +--- commons-jxpath:commons-jxpath:1.3
+|    |    |    |    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    |    |    |    +--- javax.servlet:servlet-api:2.5
+|    |    |    |    |    |    |    +--- org.antlr:antlr-runtime:3.4
+|    |    |    |    |    |    |    |    +--- org.antlr:stringtemplate:3.2.1
+|    |    |    |    |    |    |    |    |    \--- antlr:antlr:2.7.7
+|    |    |    |    |    |    |    |    \--- antlr:antlr:2.7.7
+|    |    |    |    |    |    |    +--- com.google.code.findbugs:jsr305:3.0.1 -> 3.0.2
+|    |    |    |    |    |    |    +--- com.google.guava:guava:14.0.1 -> 32.1.2-jre (*)
+|    |    |    |    |    |    |    \--- com.google.code.gson:gson:2.1 -> 2.9.1
+|    |    |    |    |    |    +--- com.netflix.servo:servo-core:0.5.3 -> 0.12.17 (*)
+|    |    |    |    |    |    +--- com.netflix.archaius:archaius-core:0.3.3 -> 0.7.6 (*)
+|    |    |    |    |    |    \--- org.apache.commons:commons-math:2.2
+|    |    |    |    |    +--- com.thoughtworks.xstream:xstream:1.4.10 -> 1.4.20
+|    |    |    |    |    |    \--- io.github.x-stream:mxparser:1.2.2
+|    |    |    |    |    |         \--- xmlpull:xmlpull:1.1.3.1
+|    |    |    |    |    +--- com.netflix.archaius:archaius-core:0.7.5 -> 0.7.6 (*)
+|    |    |    |    |    +--- javax.ws.rs:jsr311-api:1.1.1
+|    |    |    |    |    +--- com.netflix.servo:servo-core:0.10.1 -> 0.12.17 (*)
+|    |    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    |    +--- com.sun.jersey:jersey-client:1.19.1
+|    |    |    |    |    |    \--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    |    +--- com.sun.jersey.contribs:jersey-apache-client4:1.19.1
+|    |    |    |    |    |    +--- org.apache.httpcomponents:httpclient:4.1.1 -> 4.5.14 (*)
+|    |    |    |    |    |    \--- com.sun.jersey:jersey-client:1.19.1 (*)
+|    |    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    |    +--- com.google.inject:guice:4.1.0 (*)
+|    |    |    |    |    +--- com.github.vlsi.compactmap:compactmap:1.2.1
+|    |    |    |    |    |    \--- com.github.andrewoma.dexx:dexx-collections:0.2
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.8.7 -> 2.13.5 (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.8.7 -> 2.13.5 (*)
+|    |    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.8.7 -> 2.13.5 (*)
+|    |    |    |    +--- org.apache.commons:commons-lang3:3.6 -> 3.12.0
+|    |    |    |    \--- com.ecwid.consul:consul-api:1.2.1
+|    |    |    |         \--- com.google.code.gson:gson:2.3 -> 2.9.1
+|    |    |    +--- redis.clients:jedis:3.0.1 -> 3.8.0 (*)
+|    |    |    \--- org.projectlombok:lombok:1.18.4 -> 1.18.30
+|    |    +--- com.netflix.dyno:dyno-demo:1.7.2-rc2
+|    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-contrib:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-memcache:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    \--- com.netflix.dyno:dyno-contrib:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-recipes:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2 (*)
+|    |    |    |    \--- com.google.code.gson:gson:2.8.5 -> 2.9.1
+|    |    |    \--- commons-cli:commons-cli:1.4
+|    |    +--- com.netflix.archaius:archaius-core:0.7.6 (*)
+|    |    +--- com.netflix.servo:servo-core:0.12.17 (*)
+|    |    +--- com.netflix.eureka:eureka-client:1.8.6 (*)
+|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.8.7 -> 2.13.5 (*)
+|    +--- com.thoughtworks.xstream:xstream:1.4.20 (*)
+|    \--- org.rarefiedredis.redis:redis-java:0.0.17
+|         +--- redis.clients:jedis:2.6.2 -> 3.8.0 (*)
+|         \--- org.luaj:luaj-jse:3.0
++--- project :conductor-metrics
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- org.apache.commons:commons-lang3 -> 3.12.0
+|    +--- com.google.guava:guava:32.1.2-jre (*)
+|    +--- javax.ws.rs:jsr311-api:1.1.1
+|    +--- io.reactivex:rxjava:1.2.2 -> 1.3.8
+|    +--- com.netflix.spectator:spectator-reg-metrics3:0.122.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    +--- com.netflix.spectator:spectator-api:0.122.0 (*)
+|    |    \--- io.dropwizard.metrics:metrics-core:3.1.2 -> 4.2.22
+|    |         \--- org.slf4j:slf4j-api:1.7.36
+|    +--- com.netflix.spectator:spectator-reg-micrometer:0.122.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    +--- io.micrometer:micrometer-core:1.6.1 -> 1.9.17
+|    |    |    +--- org.hdrhistogram:HdrHistogram:2.1.12
+|    |    |    \--- org.latencyutils:LatencyUtils:2.0.3
+|    |    \--- com.netflix.spectator:spectator-api:0.122.0 (*)
+|    +--- io.prometheus:simpleclient:0.9.0 -> 0.15.0
+|    |    +--- io.prometheus:simpleclient_tracer_otel:0.15.0
+|    |    |    \--- io.prometheus:simpleclient_tracer_common:0.15.0
+|    |    \--- io.prometheus:simpleclient_tracer_otel_agent:0.15.0
+|    |         \--- io.prometheus:simpleclient_tracer_common:0.15.0
+|    +--- io.micrometer:micrometer-registry-prometheus:1.6.2 -> 1.9.15
+|    |    +--- io.micrometer:micrometer-core:1.9.15 -> 1.9.17 (*)
+|    |    \--- io.prometheus:simpleclient_common:0.15.0
+|    |         \--- io.prometheus:simpleclient:0.15.0 (*)
+|    \--- io.micrometer:micrometer-registry-datadog:1.9.1 -> 1.9.15
+|         +--- io.micrometer:micrometer-core:1.9.15 -> 1.9.17 (*)
+|         \--- org.slf4j:slf4j-api:1.7.36
++--- project :conductor-workflow-event-listener
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- javax.inject:javax.inject:1
+|    +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|    \--- project :common
+|         +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|         +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|         +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|         +--- javax.inject:javax.inject:1
+|         +--- org.apache.commons:commons-lang3 -> 3.12.0
+|         \--- org.apache.httpcomponents:httpclient:4.5.14 (*)
++--- project :task-event-listener
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- project :common (*)
+|    +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|    +--- javax.inject:javax.inject:1
+|    +--- org.apache.commons:commons-lang3 -> 3.12.0
+|    \--- org.apache.httpcomponents:httpclient:4.5.14 (*)
++--- project :common (*)
++--- org.springframework.boot:spring-boot-starter -> 2.7.18 (*)
++--- org.springframework.boot:spring-boot-starter-validation -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    \--- org.hibernate.validator:hibernate-validator:6.2.5.Final
+|         +--- jakarta.validation:jakarta.validation-api:2.0.2
+|         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
+|         \--- com.fasterxml:classmate:1.5.1
++--- org.springframework.boot:spring-boot-starter-web -> 2.7.18 (*)
++--- org.springframework.retry:spring-retry -> 1.3.4
++--- org.springframework.boot:spring-boot-starter-log4j2 -> 2.7.18
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    \--- org.slf4j:jul-to-slf4j:1.7.36 (*)
++--- org.springframework.boot:spring-boot-starter-actuator -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:2.7.18
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (*)
+|    |    +--- org.springframework.boot:spring-boot-actuator:2.7.18
+|    |    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    +--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    \--- org.springframework.boot:spring-boot-autoconfigure:2.7.18 (*)
+|    \--- io.micrometer:micrometer-core:1.9.17 (*)
++--- org.springdoc:springdoc-openapi-ui:1.6.+ -> 1.6.15 (*)
++--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+\--- org.glassfish.jaxb:jaxb-runtime:2.3.3
+     +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (*)
+     +--- org.glassfish.jaxb:txw2:2.3.3 -> 2.3.9
+     +--- com.sun.istack:istack-commons-runtime:3.0.11
+     \--- com.sun.activation:jakarta.activation:1.2.2
+
+runtimeElements - Elements of runtime for main. (n)
+No dependencies
+
+runtimeOnly - Runtime only dependencies for source set 'main'. (n)
+\--- org.glassfish.jaxb:jaxb-runtime:2.3.3 (n)
+
+signatures
+No dependencies
+
+sourcesElements - sources elements for main. (n)
+No dependencies
+
+testAnnotationProcessor - Annotation processors and their dependencies for source set 'test'.
+No dependencies
+
+testCompileClasspath - Compile classpath for source set 'test'.
++--- org.apache.logging.log4j:log4j-core -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-api -> 2.17.2
++--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2
+|    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.36
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-jul -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-web -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    \--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
++--- com.cisco.conductor:conductor-core:3.15.0-cisco
++--- com.cisco.conductor:conductor-rest:3.15.0-cisco
++--- com.cisco.conductor:conductor-redis-persistence:3.15.0-cisco
++--- project :conductor-metrics
++--- project :conductor-workflow-event-listener
++--- project :task-event-listener
++--- project :common
++--- org.springframework.boot:spring-boot-starter -> 2.7.18
+|    +--- org.springframework.boot:spring-boot:2.7.18
+|    |    +--- org.springframework:spring-core:5.3.31
+|    |    |    \--- org.springframework:spring-jcl:5.3.31
+|    |    \--- org.springframework:spring-context:5.3.31
+|    |         +--- org.springframework:spring-aop:5.3.31
+|    |         |    +--- org.springframework:spring-beans:5.3.31
+|    |         |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |         |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |         +--- org.springframework:spring-beans:5.3.31 (*)
+|    |         +--- org.springframework:spring-core:5.3.31 (*)
+|    |         \--- org.springframework:spring-expression:5.3.31
+|    |              \--- org.springframework:spring-core:5.3.31 (*)
+|    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.18
+|    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-starter-logging:2.7.18
+|    |    \--- org.slf4j:jul-to-slf4j:1.7.36
+|    |         \--- org.slf4j:slf4j-api:1.7.36
+|    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    +--- org.springframework:spring-core:5.3.31 (*)
+|    \--- org.yaml:snakeyaml:1.30 -> 2.0
++--- org.springframework.boot:spring-boot-starter-validation -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    \--- org.hibernate.validator:hibernate-validator:6.2.5.Final
+|         +--- jakarta.validation:jakarta.validation-api:2.0.2
+|         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
+|         \--- com.fasterxml:classmate:1.5.1
++--- org.springframework.boot:spring-boot-starter-web -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-starter-json:2.7.18
+|    |    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    |    +--- org.springframework:spring-web:5.3.31
+|    |    |    +--- org.springframework:spring-beans:5.3.31 (*)
+|    |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (c)
+|    |    |    |         +--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5 (c)
+|    |    |    |         \--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.5 (c)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5
+|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5
+|    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |         \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- org.springframework.boot:spring-boot-starter-tomcat:2.7.18
+|    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    |    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    |    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.83
+|    |         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    +--- org.springframework:spring-web:5.3.31 (*)
+|    \--- org.springframework:spring-webmvc:5.3.31
+|         +--- org.springframework:spring-aop:5.3.31 (*)
+|         +--- org.springframework:spring-beans:5.3.31 (*)
+|         +--- org.springframework:spring-context:5.3.31 (*)
+|         +--- org.springframework:spring-core:5.3.31 (*)
+|         +--- org.springframework:spring-expression:5.3.31 (*)
+|         \--- org.springframework:spring-web:5.3.31 (*)
++--- org.springframework.retry:spring-retry -> 1.3.4
++--- org.springframework.boot:spring-boot-starter-log4j2 -> 2.7.18
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    \--- org.slf4j:jul-to-slf4j:1.7.36 (*)
++--- org.springframework.boot:spring-boot-starter-actuator -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:2.7.18
+|    |    +--- org.springframework.boot:spring-boot-actuator:2.7.18
+|    |    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    +--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    \--- org.springframework.boot:spring-boot-autoconfigure:2.7.18 (*)
+|    \--- io.micrometer:micrometer-core:1.9.17
+|         \--- org.hdrhistogram:HdrHistogram:2.1.12
++--- org.springdoc:springdoc-openapi-ui:1.6.+ -> 1.6.15
+|    +--- org.springdoc:springdoc-openapi-webmvc-core:1.6.15
+|    |    +--- org.springdoc:springdoc-openapi-common:1.6.15
+|    |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.9 -> 2.7.18 (*)
+|    |    |    +--- org.springframework:spring-web:5.3.25 -> 5.3.31 (*)
+|    |    |    \--- io.swagger.core.v3:swagger-core:2.2.8
+|    |    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2 -> 2.3.3
+|    |    |         |    \--- jakarta.activation:jakarta.activation-api:1.2.2
+|    |    |         +--- org.apache.commons:commons-lang3:3.12.0
+|    |    |         +--- org.slf4j:slf4j-api:1.7.35 -> 1.7.36
+|    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.14.0 -> 2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0 -> 2.13.5
+|    |    |         |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |         |    +--- org.yaml:snakeyaml:1.31 -> 2.0
+|    |    |         |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |         |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0 -> 2.13.5 (*)
+|    |    |         +--- io.swagger.core.v3:swagger-annotations:2.2.8
+|    |    |         +--- org.yaml:snakeyaml:1.33 -> 2.0
+|    |    |         +--- io.swagger.core.v3:swagger-models:2.2.8
+|    |    |         |    \--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|    |    |         \--- jakarta.validation:jakarta.validation-api:2.0.2
+|    |    \--- org.springframework:spring-webmvc:5.3.25 -> 5.3.31 (*)
+|    +--- org.webjars:swagger-ui:4.17.1
+|    +--- org.webjars:webjars-locator-core:0.52 -> 0.50
+|    |    +--- org.slf4j:slf4j-api:1.7.36
+|    |    \--- com.fasterxml.jackson.core:jackson-core:2.13.1 -> 2.13.5 (*)
+|    \--- io.github.classgraph:classgraph:4.8.149
++--- com.cisco.conductor:conductor-common:3.15.0-cisco
++--- org.springframework.boot:spring-boot-starter-test -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-test:2.7.18
+|    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-test-autoconfigure:2.7.18
+|    |    +--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    +--- org.springframework.boot:spring-boot-test:2.7.18 (*)
+|    |    \--- org.springframework.boot:spring-boot-autoconfigure:2.7.18 (*)
+|    +--- com.jayway.jsonpath:json-path:2.7.0
+|    |    +--- net.minidev:json-smart:2.4.7 -> 2.4.11
+|    |    |    \--- net.minidev:accessors-smart:2.4.11
+|    |    |         \--- org.ow2.asm:asm:9.3
+|    |    \--- org.slf4j:slf4j-api:1.7.33 -> 1.7.36
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (*)
+|    +--- org.assertj:assertj-core:3.22.0
+|    +--- org.hamcrest:hamcrest:2.2
+|    +--- org.junit.jupiter:junit-jupiter:5.8.2
+|    |    +--- org.junit:junit-bom:5.8.2
+|    |    |    +--- org.junit.jupiter:junit-jupiter:5.8.2 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.8.2 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-params:5.8.2 (c)
+|    |    |    +--- org.junit.platform:junit-platform-engine:1.8.2 (c)
+|    |    |    +--- org.junit.vintage:junit-vintage-engine:5.8.2 (c)
+|    |    |    \--- org.junit.platform:junit-platform-commons:1.8.2 (c)
+|    |    +--- org.junit.jupiter:junit-jupiter-api:5.8.2
+|    |    |    +--- org.junit:junit-bom:5.8.2 (*)
+|    |    |    +--- org.opentest4j:opentest4j:1.2.0
+|    |    |    +--- org.junit.platform:junit-platform-commons:1.8.2
+|    |    |    |    +--- org.junit:junit-bom:5.8.2 (*)
+|    |    |    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    |    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    |    \--- org.junit.jupiter:junit-jupiter-params:5.8.2
+|    |         +--- org.junit:junit-bom:5.8.2 (*)
+|    |         +--- org.junit.jupiter:junit-jupiter-api:5.8.2 (*)
+|    |         \--- org.apiguardian:apiguardian-api:1.1.2
+|    +--- org.mockito:mockito-core:4.5.1
+|    |    +--- net.bytebuddy:byte-buddy:1.12.9 -> 1.12.23
+|    |    \--- net.bytebuddy:byte-buddy-agent:1.12.9 -> 1.12.23
+|    +--- org.mockito:mockito-junit-jupiter:4.5.1
+|    |    \--- org.mockito:mockito-core:4.5.1 (*)
+|    +--- org.skyscreamer:jsonassert:1.5.1
+|    |    \--- com.vaadin.external.google:android-json:0.0.20131108.vaadin1
+|    +--- org.springframework:spring-core:5.3.31 (*)
+|    +--- org.springframework:spring-test:5.3.31
+|    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    \--- org.xmlunit:xmlunit-core:2.9.1
++--- junit:junit -> 4.13.2
+|    \--- org.hamcrest:hamcrest-core:1.3 -> 2.2
+|         \--- org.hamcrest:hamcrest:2.2
++--- org.junit.vintage:junit-vintage-engine -> 5.8.2
+|    +--- org.junit:junit-bom:5.8.2 (*)
+|    +--- org.junit.platform:junit-platform-engine:1.8.2
+|    |    +--- org.junit:junit-bom:5.8.2 (*)
+|    |    +--- org.opentest4j:opentest4j:1.2.0
+|    |    +--- org.junit.platform:junit-platform-commons:1.8.2 (*)
+|    |    \--- org.apiguardian:apiguardian-api:1.1.2
+|    +--- junit:junit:4.13.2 (*)
+|    \--- org.apiguardian:apiguardian-api:1.1.2
++--- io.grpc:grpc-testing:1.57.+ -> 1.57.2
+|    +--- io.grpc:grpc-core:1.57.2
+|    |    \--- io.grpc:grpc-api:1.57.2
+|    |         +--- com.google.code.findbugs:jsr305:3.0.2
+|    |         \--- com.google.errorprone:error_prone_annotations:2.18.0
+|    +--- io.grpc:grpc-stub:1.57.2
+|    |    +--- io.grpc:grpc-api:1.57.2 (*)
+|    |    \--- com.google.guava:guava:32.0.1-android
+|    |         +--- com.google.guava:failureaccess:1.0.1
+|    |         +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |         +--- com.google.code.findbugs:jsr305:3.0.2
+|    |         +--- org.checkerframework:checker-qual:3.33.0
+|    |         +--- com.google.errorprone:error_prone_annotations:2.18.0
+|    |         \--- com.google.j2objc:j2objc-annotations:2.8
+|    \--- junit:junit:4.13.2 (*)
++--- com.google.protobuf:protobuf-java:3.21.12
++--- io.grpc:grpc-protobuf:1.57.+ -> 1.57.2
+|    +--- io.grpc:grpc-api:1.57.2 (*)
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- com.google.protobuf:protobuf-java:3.22.3 -> 3.21.12
+|    +--- com.google.api.grpc:proto-google-common-protos:2.17.0
+|    |    \--- com.google.protobuf:protobuf-java:3.21.12
+|    \--- io.grpc:grpc-protobuf-lite:1.57.2
+|         \--- io.grpc:grpc-api:1.57.2 (*)
+\--- io.grpc:grpc-stub:1.57.+ -> 1.57.2 (*)
+
+testCompileOnly - Compile only dependencies for source set 'test'. (n)
+No dependencies
+
+testImplementation - Implementation only dependencies for source set 'test'. (n)
++--- org.springframework.boot:spring-boot-starter-test (n)
++--- org.springframework.boot:spring-boot-starter-log4j2 (n)
++--- junit:junit (n)
++--- org.junit.vintage:junit-vintage-engine (n)
++--- io.grpc:grpc-testing:1.57.+ (n)
++--- com.google.protobuf:protobuf-java:3.21.12 (n)
++--- io.grpc:grpc-protobuf:1.57.+ (n)
+\--- io.grpc:grpc-stub:1.57.+ (n)
+
+testResultsElementsForTest - Directory containing binary results of running tests for the test Test Suite's test target. (n)
+No dependencies
+
+testRuntimeClasspath - Runtime classpath of source set 'test'.
++--- org.apache.logging.log4j:log4j-core -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-api -> 2.17.2
++--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2
+|    +--- org.slf4j:slf4j-api:1.7.25 -> 1.7.36
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    \--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
++--- org.apache.logging.log4j:log4j-jul -> 2.17.2
+|    \--- org.apache.logging.log4j:log4j-api:2.17.2
++--- org.apache.logging.log4j:log4j-web -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    \--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
++--- com.cisco.conductor:conductor-core:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5
+|    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.module:jackson-module-afterburner:2.13.5 (c)
+|    |         +--- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.5 (c)
+|    |         \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5 (c)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- org.yaml:snakeyaml:1.31 -> 2.0
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- joda-time:joda-time:2.10.8
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.5
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3
+|    |    |    |    \--- jakarta.activation:jakarta.activation-api:1.2.2
+|    |    |    +--- jakarta.activation:jakarta.activation-api:1.2.1 -> 1.2.2
+|    |    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco
+|    |    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    |    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    |    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    |    +--- com.netflix.conductor:conductor-annotations:3.15.0-cisco -> 3.15.0
+|    |    |    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    |    |    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    |    |    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    |    |    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    |    |    \--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    |    +--- org.apache.commons:commons-lang3:3.12.0
+|    |    +--- org.apache.bval:bval-jsr:2.0.6
+|    |    +--- com.google.protobuf:protobuf-java:3.24.3 -> 3.21.12
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.15.0 -> 2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.core:jackson-core:2.15.0 -> 2.13.5 (*)
+|    |    \--- com.fasterxml.jackson.module:jackson-module-afterburner:2.15.0 -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:2.15.0 -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:2.15.0 -> 2.13.5 (*)
+|    +--- commons-io:commons-io:2.7
+|    +--- com.google.protobuf:protobuf-java:3.24.3 -> 3.21.12
+|    +--- org.apache.commons:commons-lang3:3.12.0
+|    +--- com.fasterxml.jackson.core:jackson-core:2.15.0 -> 2.13.5 (*)
+|    +--- com.spotify:completable-futures:0.3.3
+|    +--- com.jayway.jsonpath:json-path:2.4.0 -> 2.7.0
+|    |    +--- net.minidev:json-smart:2.4.7 -> 2.4.11
+|    |    |    \--- net.minidev:accessors-smart:2.4.11
+|    |    |         \--- org.ow2.asm:asm:9.3
+|    |    \--- org.slf4j:slf4j-api:1.7.33 -> 1.7.36
+|    +--- io.reactivex:rxjava:1.2.2 -> 1.3.8
+|    +--- com.netflix.spectator:spectator-api:0.122.0
+|    |    \--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    +--- org.apache.bval:bval-jsr:2.0.6
+|    +--- com.github.ben-manes.caffeine:caffeine:2.9.3
+|    |    +--- org.checkerframework:checker-qual:3.19.0 -> 3.33.0
+|    |    \--- com.google.errorprone:error_prone_annotations:2.10.0 -> 2.18.0
+|    +--- org.openjdk.nashorn:nashorn-core:15.4
+|    |    +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    +--- org.ow2.asm:asm-commons:7.3.1
+|    |    |    +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    |    +--- org.ow2.asm:asm-tree:7.3.1
+|    |    |    |    \--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |    |    \--- org.ow2.asm:asm-analysis:7.3.1
+|    |    |         \--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |    +--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |    \--- org.ow2.asm:asm-util:7.3.1
+|    |         +--- org.ow2.asm:asm:7.3.1 -> 9.3
+|    |         +--- org.ow2.asm:asm-tree:7.3.1 (*)
+|    |         \--- org.ow2.asm:asm-analysis:7.3.1 (*)
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (*)
+|    \--- jakarta.activation:jakarta.activation-api:2.0.0 -> 1.2.2
++--- com.cisco.conductor:conductor-rest:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- org.springframework.boot:spring-boot-starter-web:2.7.18
+|    |    +--- org.springframework.boot:spring-boot-starter:2.7.18
+|    |    |    +--- org.springframework.boot:spring-boot:2.7.18
+|    |    |    |    +--- org.springframework:spring-core:5.3.31
+|    |    |    |    |    \--- org.springframework:spring-jcl:5.3.31
+|    |    |    |    \--- org.springframework:spring-context:5.3.31
+|    |    |    |         +--- org.springframework:spring-aop:5.3.31
+|    |    |    |         |    +--- org.springframework:spring-beans:5.3.31
+|    |    |    |         |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         +--- org.springframework:spring-beans:5.3.31 (*)
+|    |    |    |         +--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    |         \--- org.springframework:spring-expression:5.3.31
+|    |    |    |              \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.18
+|    |    |    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    |    +--- org.springframework.boot:spring-boot-starter-logging:2.7.18
+|    |    |    |    \--- org.slf4j:jul-to-slf4j:1.7.36
+|    |    |    |         \--- org.slf4j:slf4j-api:1.7.36
+|    |    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    |    |    +--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    \--- org.yaml:snakeyaml:1.30 -> 2.0
+|    |    +--- org.springframework.boot:spring-boot-starter-json:2.7.18
+|    |    |    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    |    |    +--- org.springframework:spring-web:5.3.31
+|    |    |    |    +--- org.springframework:spring-beans:5.3.31 (*)
+|    |    |    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    |    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.5 (*)
+|    |    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (*)
+|    |    |    \--- com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.5
+|    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.13.5 (*)
+|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    |         \--- com.fasterxml.jackson:jackson-bom:2.13.5 (*)
+|    |    +--- org.springframework.boot:spring-boot-starter-tomcat:2.7.18
+|    |    |    +--- jakarta.annotation:jakarta.annotation-api:1.3.5
+|    |    |    +--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    |    |    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    |    |    \--- org.apache.tomcat.embed:tomcat-embed-websocket:9.0.83
+|    |    |         \--- org.apache.tomcat.embed:tomcat-embed-core:9.0.83
+|    |    +--- org.springframework:spring-web:5.3.31 (*)
+|    |    \--- org.springframework:spring-webmvc:5.3.31
+|    |         +--- org.springframework:spring-aop:5.3.31 (*)
+|    |         +--- org.springframework:spring-beans:5.3.31 (*)
+|    |         +--- org.springframework:spring-context:5.3.31 (*)
+|    |         +--- org.springframework:spring-core:5.3.31 (*)
+|    |         +--- org.springframework:spring-expression:5.3.31 (*)
+|    |         \--- org.springframework:spring-web:5.3.31 (*)
+|    +--- com.netflix.runtime:health-api:1.1.4
+|    \--- org.springdoc:springdoc-openapi-ui:1.6.15
+|         +--- org.springdoc:springdoc-openapi-webmvc-core:1.6.15
+|         |    +--- org.springdoc:springdoc-openapi-common:1.6.15
+|         |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.9 -> 2.7.18 (*)
+|         |    |    +--- org.springframework:spring-web:5.3.25 -> 5.3.31 (*)
+|         |    |    \--- io.swagger.core.v3:swagger-core:2.2.8
+|         |    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2 -> 2.3.3 (*)
+|         |    |         +--- org.apache.commons:commons-lang3:3.12.0
+|         |    |         +--- org.slf4j:slf4j-api:1.7.35 -> 1.7.36
+|         |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0 -> 2.13.5 (*)
+|         |    |         +--- io.swagger.core.v3:swagger-annotations:2.2.8
+|         |    |         +--- org.yaml:snakeyaml:1.33 -> 2.0
+|         |    |         +--- io.swagger.core.v3:swagger-models:2.2.8
+|         |    |         |    \--- com.fasterxml.jackson.core:jackson-annotations:2.14.0 -> 2.13.5 (*)
+|         |    |         \--- jakarta.validation:jakarta.validation-api:2.0.2
+|         |    \--- org.springframework:spring-webmvc:5.3.25 -> 5.3.31 (*)
+|         +--- org.webjars:swagger-ui:4.17.1
+|         +--- org.webjars:webjars-locator-core:0.52 -> 0.50
+|         |    +--- org.slf4j:slf4j-api:1.7.36
+|         |    \--- com.fasterxml.jackson.core:jackson-core:2.13.1 -> 2.13.5 (*)
+|         \--- io.github.classgraph:classgraph:4.8.149
++--- com.cisco.conductor:conductor-redis-persistence:3.15.0-cisco
+|    +--- org.apache.logging.log4j:log4j-core:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:{strictly 2.17.2} -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:{strictly 2.17.2} -> 2.17.2 (*)
+|    +--- org.yaml:snakeyaml:{strictly 2.0} -> 2.0
+|    +--- com.fasterxml.jackson.core:jackson-core:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-databind:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.core:jackson-annotations:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-joda:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- com.fasterxml.jackson.module:jackson-module-afterburner:{strictly 2.15.0} -> 2.13.5 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api:2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web:2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- redis.clients:jedis:3.3.0 -> 3.8.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    \--- org.apache.commons:commons-pool2:2.11.1
+|    +--- com.netflix.dyno-queues:dyno-queues-redis:2.0.20
+|    |    +--- com.netflix.dyno-queues:dyno-queues-core:2.0.20
+|    |    |    \--- com.netflix.dyno:dyno-core:1.7.2-rc2
+|    |    |         +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |         +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |         +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |         +--- org.apache.httpcomponents:httpclient:4.2.1 -> 4.5.14
+|    |    |         |    +--- org.apache.httpcomponents:httpcore:4.4.16
+|    |    |         |    +--- commons-logging:commons-logging:1.2
+|    |    |         |    \--- commons-codec:commons-codec:1.11 -> 1.15
+|    |    |         +--- com.sun.jersey:jersey-core:1.11 -> 1.19.1
+|    |    |         |    \--- javax.ws.rs:jsr311-api:1.1.1
+|    |    |         +--- org.apache.commons:commons-math:2.2
+|    |    |         +--- org.apache.commons:commons-lang3:3.6 -> 3.12.0
+|    |    |         \--- commons-io:commons-io:2.4 -> 2.7
+|    |    +--- com.google.inject:guice:4.1.0
+|    |    |    +--- javax.inject:javax.inject:1
+|    |    |    +--- aopalliance:aopalliance:1.0
+|    |    |    \--- com.google.guava:guava:19.0 -> 32.1.2-jre
+|    |    |         +--- com.google.guava:guava-parent:32.1.2-jre
+|    |    |         |    +--- com.google.code.findbugs:jsr305:3.0.2 (c)
+|    |    |         |    +--- org.checkerframework:checker-qual:3.33.0 (c)
+|    |    |         |    \--- com.google.errorprone:error_prone_annotations:2.18.0 (c)
+|    |    |         +--- com.google.guava:failureaccess:1.0.1
+|    |    |         +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+|    |    |         +--- com.google.code.findbugs:jsr305 -> 3.0.2
+|    |    |         +--- org.checkerframework:checker-qual -> 3.33.0
+|    |    |         \--- com.google.errorprone:error_prone_annotations -> 2.18.0
+|    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2
+|    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-contrib:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    +--- com.google.inject:guice:4.1.0 (*)
+|    |    |    |    +--- com.netflix.archaius:archaius-core:0.7.6
+|    |    |    |    |    +--- com.google.code.findbugs:jsr305:3.0.1 -> 3.0.2
+|    |    |    |    |    +--- commons-configuration:commons-configuration:1.8
+|    |    |    |    |    |    +--- commons-lang:commons-lang:2.6
+|    |    |    |    |    |    \--- commons-logging:commons-logging:1.1.1 -> 1.2
+|    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    +--- com.google.guava:guava:16.0 -> 32.1.2-jre (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.4.3 -> 2.13.5 (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.4.3 -> 2.13.5 (*)
+|    |    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.4.3 -> 2.13.5 (*)
+|    |    |    |    +--- com.netflix.servo:servo-core:0.12.17
+|    |    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    |    \--- com.google.guava:guava:19.0 -> 32.1.2-jre (*)
+|    |    |    |    +--- com.netflix.eureka:eureka-client:1.8.6
+|    |    |    |    |    +--- org.codehaus.jettison:jettison:1.3.7
+|    |    |    |    |    |    \--- stax:stax-api:1.0.1
+|    |    |    |    |    +--- com.netflix.netflix-commons:netflix-eventbus:0.3.0
+|    |    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    |    +--- com.netflix.netflix-commons:netflix-infix:0.3.0
+|    |    |    |    |    |    |    +--- org.slf4j:slf4j-api:1.6.4 -> 1.7.36
+|    |    |    |    |    |    |    +--- commons-jxpath:commons-jxpath:1.3
+|    |    |    |    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    |    |    |    +--- javax.servlet:servlet-api:2.5
+|    |    |    |    |    |    |    +--- org.antlr:antlr-runtime:3.4
+|    |    |    |    |    |    |    |    +--- org.antlr:stringtemplate:3.2.1
+|    |    |    |    |    |    |    |    |    \--- antlr:antlr:2.7.7
+|    |    |    |    |    |    |    |    \--- antlr:antlr:2.7.7
+|    |    |    |    |    |    |    +--- com.google.code.findbugs:jsr305:3.0.1 -> 3.0.2
+|    |    |    |    |    |    |    +--- com.google.guava:guava:14.0.1 -> 32.1.2-jre (*)
+|    |    |    |    |    |    |    \--- com.google.code.gson:gson:2.1 -> 2.9.1
+|    |    |    |    |    |    +--- com.netflix.servo:servo-core:0.5.3 -> 0.12.17 (*)
+|    |    |    |    |    |    +--- com.netflix.archaius:archaius-core:0.3.3 -> 0.7.6 (*)
+|    |    |    |    |    |    \--- org.apache.commons:commons-math:2.2
+|    |    |    |    |    +--- com.thoughtworks.xstream:xstream:1.4.10 -> 1.4.20
+|    |    |    |    |    |    \--- io.github.x-stream:mxparser:1.2.2
+|    |    |    |    |    |         \--- xmlpull:xmlpull:1.1.3.1
+|    |    |    |    |    +--- com.netflix.archaius:archaius-core:0.7.5 -> 0.7.6 (*)
+|    |    |    |    |    +--- javax.ws.rs:jsr311-api:1.1.1
+|    |    |    |    |    +--- com.netflix.servo:servo-core:0.10.1 -> 0.12.17 (*)
+|    |    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    |    +--- com.sun.jersey:jersey-client:1.19.1
+|    |    |    |    |    |    \--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    |    +--- com.sun.jersey.contribs:jersey-apache-client4:1.19.1
+|    |    |    |    |    |    +--- org.apache.httpcomponents:httpclient:4.1.1 -> 4.5.14 (*)
+|    |    |    |    |    |    \--- com.sun.jersey:jersey-client:1.19.1 (*)
+|    |    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    |    +--- com.google.inject:guice:4.1.0 (*)
+|    |    |    |    |    +--- com.github.vlsi.compactmap:compactmap:1.2.1
+|    |    |    |    |    |    \--- com.github.andrewoma.dexx:dexx-collections:0.2
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.8.7 -> 2.13.5 (*)
+|    |    |    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.8.7 -> 2.13.5 (*)
+|    |    |    |    |    \--- com.fasterxml.jackson.core:jackson-databind:2.8.7 -> 2.13.5 (*)
+|    |    |    |    +--- org.apache.commons:commons-lang3:3.6 -> 3.12.0
+|    |    |    |    \--- com.ecwid.consul:consul-api:1.2.1
+|    |    |    |         \--- com.google.code.gson:gson:2.3 -> 2.9.1
+|    |    |    +--- redis.clients:jedis:3.0.1 -> 3.8.0 (*)
+|    |    |    \--- org.projectlombok:lombok:1.18.4 -> 1.18.30
+|    |    +--- com.netflix.dyno:dyno-demo:1.7.2-rc2
+|    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-contrib:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-memcache:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.21 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    \--- com.netflix.dyno:dyno-contrib:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2 (*)
+|    |    |    +--- com.netflix.dyno:dyno-recipes:1.7.2-rc2
+|    |    |    |    +--- joda-time:joda-time:2.3 -> 2.10.8
+|    |    |    |    +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.36
+|    |    |    |    +--- com.googlecode.json-simple:json-simple:1.1
+|    |    |    |    +--- org.apache.httpcomponents:httpclient:4.4.1 -> 4.5.14 (*)
+|    |    |    |    +--- com.sun.jersey:jersey-core:1.19.1 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-core:1.7.2-rc2 (*)
+|    |    |    |    +--- com.netflix.dyno:dyno-jedis:1.7.2-rc2 (*)
+|    |    |    |    \--- com.google.code.gson:gson:2.8.5 -> 2.9.1
+|    |    |    \--- commons-cli:commons-cli:1.4
+|    |    +--- com.netflix.archaius:archaius-core:0.7.6 (*)
+|    |    +--- com.netflix.servo:servo-core:0.12.17 (*)
+|    |    +--- com.netflix.eureka:eureka-client:1.8.6 (*)
+|    |    \--- com.fasterxml.jackson.core:jackson-databind:2.8.7 -> 2.13.5 (*)
+|    +--- com.thoughtworks.xstream:xstream:1.4.20 (*)
+|    \--- org.rarefiedredis.redis:redis-java:0.0.17
+|         +--- redis.clients:jedis:2.6.2 -> 3.8.0 (*)
+|         \--- org.luaj:luaj-jse:3.0
++--- project :conductor-metrics
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- org.apache.commons:commons-lang3 -> 3.12.0
+|    +--- com.google.guava:guava:32.1.2-jre (*)
+|    +--- javax.ws.rs:jsr311-api:1.1.1
+|    +--- io.reactivex:rxjava:1.2.2 -> 1.3.8
+|    +--- com.netflix.spectator:spectator-reg-metrics3:0.122.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    +--- com.netflix.spectator:spectator-api:0.122.0 (*)
+|    |    \--- io.dropwizard.metrics:metrics-core:3.1.2 -> 4.2.22
+|    |         \--- org.slf4j:slf4j-api:1.7.36
+|    +--- com.netflix.spectator:spectator-reg-micrometer:0.122.0
+|    |    +--- org.slf4j:slf4j-api:1.7.30 -> 1.7.36
+|    |    +--- io.micrometer:micrometer-core:1.6.1 -> 1.9.17
+|    |    |    +--- org.hdrhistogram:HdrHistogram:2.1.12
+|    |    |    \--- org.latencyutils:LatencyUtils:2.0.3
+|    |    \--- com.netflix.spectator:spectator-api:0.122.0 (*)
+|    +--- io.prometheus:simpleclient:0.9.0 -> 0.15.0
+|    |    +--- io.prometheus:simpleclient_tracer_otel:0.15.0
+|    |    |    \--- io.prometheus:simpleclient_tracer_common:0.15.0
+|    |    \--- io.prometheus:simpleclient_tracer_otel_agent:0.15.0
+|    |         \--- io.prometheus:simpleclient_tracer_common:0.15.0
+|    +--- io.micrometer:micrometer-registry-prometheus:1.6.2 -> 1.9.15
+|    |    +--- io.micrometer:micrometer-core:1.9.15 -> 1.9.17 (*)
+|    |    \--- io.prometheus:simpleclient_common:0.15.0
+|    |         \--- io.prometheus:simpleclient:0.15.0 (*)
+|    \--- io.micrometer:micrometer-registry-datadog:1.9.1 -> 1.9.15
+|         +--- io.micrometer:micrometer-core:1.9.15 -> 1.9.17 (*)
+|         \--- org.slf4j:slf4j-api:1.7.36
++--- project :conductor-workflow-event-listener
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- javax.inject:javax.inject:1
+|    +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|    \--- project :common
+|         +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|         +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|         +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|         +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|         +--- javax.inject:javax.inject:1
+|         +--- org.apache.commons:commons-lang3 -> 3.12.0
+|         \--- org.apache.httpcomponents:httpclient:4.5.14 (*)
++--- project :task-event-listener
+|    +--- org.apache.logging.log4j:log4j-core -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-api -> 2.17.2
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul -> 2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-web -> 2.17.2 (*)
+|    +--- com.cisco.conductor:conductor-core:3.15.0-cisco (*)
+|    +--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
+|    +--- project :common (*)
+|    +--- com.netflix.conductor:conductor-annotations:3.15.0 (*)
+|    +--- javax.inject:javax.inject:1
+|    +--- org.apache.commons:commons-lang3 -> 3.12.0
+|    \--- org.apache.httpcomponents:httpclient:4.5.14 (*)
++--- project :common (*)
++--- org.springframework.boot:spring-boot-starter -> 2.7.18 (*)
++--- org.springframework.boot:spring-boot-starter-validation -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.apache.tomcat.embed:tomcat-embed-el:9.0.83
+|    \--- org.hibernate.validator:hibernate-validator:6.2.5.Final
+|         +--- jakarta.validation:jakarta.validation-api:2.0.2
+|         +--- org.jboss.logging:jboss-logging:3.4.1.Final -> 3.4.3.Final
+|         \--- com.fasterxml:classmate:1.5.1
++--- org.springframework.boot:spring-boot-starter-web -> 2.7.18 (*)
++--- org.springframework.retry:spring-retry -> 1.3.4
++--- org.springframework.boot:spring-boot-starter-log4j2 -> 2.7.18
+|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-core:2.17.2 (*)
+|    +--- org.apache.logging.log4j:log4j-jul:2.17.2 (*)
+|    \--- org.slf4j:jul-to-slf4j:1.7.36 (*)
++--- org.springframework.boot:spring-boot-starter-actuator -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-actuator-autoconfigure:2.7.18
+|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.5 (*)
+|    |    +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.5 (*)
+|    |    +--- org.springframework.boot:spring-boot-actuator:2.7.18
+|    |    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    +--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    \--- org.springframework.boot:spring-boot-autoconfigure:2.7.18 (*)
+|    \--- io.micrometer:micrometer-core:1.9.17 (*)
++--- org.springdoc:springdoc-openapi-ui:1.6.+ -> 1.6.15 (*)
++--- com.cisco.conductor:conductor-common:3.15.0-cisco (*)
++--- org.glassfish.jaxb:jaxb-runtime:2.3.3
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (*)
+|    +--- org.glassfish.jaxb:txw2:2.3.3 -> 2.3.9
+|    +--- com.sun.istack:istack-commons-runtime:3.0.11
+|    \--- com.sun.activation:jakarta.activation:1.2.2
++--- org.springframework.boot:spring-boot-starter-test -> 2.7.18
+|    +--- org.springframework.boot:spring-boot-starter:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-test:2.7.18
+|    |    \--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    +--- org.springframework.boot:spring-boot-test-autoconfigure:2.7.18
+|    |    +--- org.springframework.boot:spring-boot:2.7.18 (*)
+|    |    +--- org.springframework.boot:spring-boot-test:2.7.18 (*)
+|    |    \--- org.springframework.boot:spring-boot-autoconfigure:2.7.18 (*)
+|    +--- com.jayway.jsonpath:json-path:2.7.0 (*)
+|    +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.3 (*)
+|    +--- org.assertj:assertj-core:3.22.0
+|    +--- org.hamcrest:hamcrest:2.2
+|    +--- org.junit.jupiter:junit-jupiter:5.8.2
+|    |    +--- org.junit:junit-bom:5.8.2
+|    |    |    +--- org.junit.jupiter:junit-jupiter:5.8.2 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-api:5.8.2 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-engine:5.8.2 (c)
+|    |    |    +--- org.junit.jupiter:junit-jupiter-params:5.8.2 (c)
+|    |    |    +--- org.junit.platform:junit-platform-engine:1.8.2 (c)
+|    |    |    +--- org.junit.vintage:junit-vintage-engine:5.8.2 (c)
+|    |    |    \--- org.junit.platform:junit-platform-commons:1.8.2 (c)
+|    |    +--- org.junit.jupiter:junit-jupiter-api:5.8.2
+|    |    |    +--- org.junit:junit-bom:5.8.2 (*)
+|    |    |    +--- org.opentest4j:opentest4j:1.2.0
+|    |    |    \--- org.junit.platform:junit-platform-commons:1.8.2
+|    |    |         \--- org.junit:junit-bom:5.8.2 (*)
+|    |    +--- org.junit.jupiter:junit-jupiter-params:5.8.2
+|    |    |    +--- org.junit:junit-bom:5.8.2 (*)
+|    |    |    \--- org.junit.jupiter:junit-jupiter-api:5.8.2 (*)
+|    |    \--- org.junit.jupiter:junit-jupiter-engine:5.8.2
+|    |         +--- org.junit:junit-bom:5.8.2 (*)
+|    |         +--- org.junit.platform:junit-platform-engine:1.8.2
+|    |         |    +--- org.junit:junit-bom:5.8.2 (*)
+|    |         |    +--- org.opentest4j:opentest4j:1.2.0
+|    |         |    \--- org.junit.platform:junit-platform-commons:1.8.2 (*)
+|    |         \--- org.junit.jupiter:junit-jupiter-api:5.8.2 (*)
+|    +--- org.mockito:mockito-core:4.5.1
+|    |    +--- net.bytebuddy:byte-buddy:1.12.9 -> 1.12.23
+|    |    +--- net.bytebuddy:byte-buddy-agent:1.12.9 -> 1.12.23
+|    |    \--- org.objenesis:objenesis:3.2
+|    +--- org.mockito:mockito-junit-jupiter:4.5.1
+|    |    +--- org.mockito:mockito-core:4.5.1 (*)
+|    |    \--- org.junit.jupiter:junit-jupiter-api:5.8.2 (*)
+|    +--- org.skyscreamer:jsonassert:1.5.1
+|    |    \--- com.vaadin.external.google:android-json:0.0.20131108.vaadin1
+|    +--- org.springframework:spring-core:5.3.31 (*)
+|    +--- org.springframework:spring-test:5.3.31
+|    |    \--- org.springframework:spring-core:5.3.31 (*)
+|    \--- org.xmlunit:xmlunit-core:2.9.1
++--- junit:junit -> 4.13.2
+|    \--- org.hamcrest:hamcrest-core:1.3 -> 2.2
+|         \--- org.hamcrest:hamcrest:2.2
++--- org.junit.vintage:junit-vintage-engine -> 5.8.2
+|    +--- org.junit:junit-bom:5.8.2 (*)
+|    +--- org.junit.platform:junit-platform-engine:1.8.2 (*)
+|    \--- junit:junit:4.13.2 (*)
++--- io.grpc:grpc-testing:1.57.+ -> 1.57.2
+|    +--- io.grpc:grpc-core:1.57.2
+|    |    +--- io.grpc:grpc-api:1.57.2
+|    |    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    |    +--- com.google.errorprone:error_prone_annotations:2.18.0
+|    |    |    \--- com.google.guava:guava:32.0.1-android -> 32.1.2-jre (*)
+|    |    +--- com.google.code.gson:gson:2.10.1 -> 2.9.1
+|    |    +--- com.google.android:annotations:4.1.1.4
+|    |    +--- org.codehaus.mojo:animal-sniffer-annotations:1.23
+|    |    +--- com.google.errorprone:error_prone_annotations:2.18.0
+|    |    +--- com.google.guava:guava:32.0.1-android -> 32.1.2-jre (*)
+|    |    +--- io.perfmark:perfmark-api:0.26.0
+|    |    \--- io.grpc:grpc-context:1.57.2
+|    |         \--- io.grpc:grpc-api:1.57.2 (*)
+|    +--- io.grpc:grpc-stub:1.57.2
+|    |    +--- io.grpc:grpc-api:1.57.2 (*)
+|    |    +--- com.google.guava:guava:32.0.1-android -> 32.1.2-jre (*)
+|    |    \--- com.google.errorprone:error_prone_annotations:2.18.0
+|    +--- junit:junit:4.13.2 (*)
+|    \--- io.grpc:grpc-api:1.57.2 (*)
++--- com.google.protobuf:protobuf-java:3.21.12
++--- io.grpc:grpc-protobuf:1.57.+ -> 1.57.2
+|    +--- io.grpc:grpc-api:1.57.2 (*)
+|    +--- com.google.code.findbugs:jsr305:3.0.2
+|    +--- com.google.protobuf:protobuf-java:3.22.3 -> 3.21.12
+|    +--- com.google.api.grpc:proto-google-common-protos:2.17.0
+|    |    \--- com.google.protobuf:protobuf-java:3.21.12
+|    +--- io.grpc:grpc-protobuf-lite:1.57.2
+|    |    +--- io.grpc:grpc-api:1.57.2 (*)
+|    |    +--- com.google.code.findbugs:jsr305:3.0.2
+|    |    \--- com.google.guava:guava:32.0.1-android -> 32.1.2-jre (*)
+|    \--- com.google.guava:guava:32.0.1-android -> 32.1.2-jre (*)
+\--- io.grpc:grpc-stub:1.57.+ -> 1.57.2 (*)
+
+testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
+No dependencies
+
+(c) - dependency constraint
+(*) - dependencies omitted (listed previously)
+
+(n) - Not resolved (configuration is not meant to be resolved)
+
+A web-based, searchable dependency report is available by adding the --scan option.
+
+Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
+
+You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
+
+See https://docs.gradle.org/7.6.2/userguide/command_line_interface.html#sec:command_line_warnings
+
+BUILD SUCCESSFUL in 14s
+1 actionable task: 1 executed
+
+Publishing build scan...
+https://gradle.com/s/x2zxwefkwbbt6
+

--- a/event-queue/amqp/dependencies.lock
+++ b/event-queue/amqp/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -39,10 +39,10 @@
             "locked": "2.17.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "runtimeClasspath": {
@@ -121,10 +121,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testRuntimeClasspath": {
@@ -168,10 +168,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     }
 }

--- a/event-queue/nats-streaming/dependencies.lock
+++ b/event-queue/nats-streaming/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -42,10 +42,10 @@
             "locked": "2.17.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "runtimeClasspath": {
@@ -130,10 +130,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testRuntimeClasspath": {
@@ -180,10 +180,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     }
 }

--- a/event-queue/nats/dependencies.lock
+++ b/event-queue/nats/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -39,10 +39,10 @@
             "locked": "2.17.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "runtimeClasspath": {
@@ -121,10 +121,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testRuntimeClasspath": {
@@ -168,10 +168,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     }
 }

--- a/external-payload-storage/azureblob-storage/dependencies.lock
+++ b/external-payload-storage/azureblob-storage/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -33,7 +33,7 @@
             "locked": "2.17.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "runtimeClasspath": {
@@ -100,10 +100,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testRuntimeClasspath": {
@@ -141,10 +141,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     }
 }

--- a/external-payload-storage/postgres-external-storage/dependencies.lock
+++ b/external-payload-storage/postgres-external-storage/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -39,13 +39,13 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "runtimeClasspath": {
@@ -83,7 +83,7 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testCompileClasspath": {
@@ -127,16 +127,16 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:postgresql": {
             "locked": "1.18.3"
@@ -183,16 +183,16 @@
             "locked": "1.6.15"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:postgresql": {
             "locked": "1.18.3"

--- a/index/es7-persistence/dependencies.lock
+++ b/index/es7-persistence/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -51,7 +51,7 @@
             "locked": "7.6.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -136,7 +136,7 @@
     },
     "shadow": {
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -201,10 +201,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -215,7 +215,7 @@
     },
     "testRuntime": {
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -310,10 +310,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"

--- a/lock/zookeeper-lock/dependencies.lock
+++ b/lock/zookeeper-lock/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -30,7 +30,7 @@
             "locked": "2.17.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "runtimeClasspath": {
@@ -94,10 +94,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testRuntimeClasspath": {
@@ -135,10 +135,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     }
 }

--- a/metrics/dependencies.lock
+++ b/metrics/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -54,10 +54,10 @@
             "locked": "2.17.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "runtimeClasspath": {
@@ -169,13 +169,13 @@
             "locked": "5.12.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:mockserver": {
             "locked": "1.18.3"
@@ -240,13 +240,13 @@
             "locked": "5.12.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:mockserver": {
             "locked": "1.18.3"

--- a/persistence/common-persistence/dependencies.lock
+++ b/persistence/common-persistence/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -106,10 +106,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testRuntimeClasspath": {
@@ -150,10 +150,10 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     }
 }

--- a/persistence/mysql-persistence/dependencies.lock
+++ b/persistence/mysql-persistence/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -48,10 +48,10 @@
             "locked": "8.5.13"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -131,7 +131,7 @@
             "locked": "8.5.13"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testCompileClasspath": {
@@ -211,13 +211,13 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:elasticsearch": {
             "locked": "1.18.3"
@@ -333,13 +333,13 @@
             "locked": "5.8.2"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:elasticsearch": {
             "locked": "1.18.3"

--- a/persistence/postgres-persistence/dependencies.lock
+++ b/persistence/postgres-persistence/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -48,10 +48,10 @@
             "locked": "42.3.8"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.retry:spring-retry": {
             "locked": "1.3.4"
@@ -131,7 +131,7 @@
             "locked": "42.3.8"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testCompileClasspath": {
@@ -211,13 +211,13 @@
             "locked": "42.3.8"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:elasticsearch": {
             "locked": "1.18.3"
@@ -333,13 +333,13 @@
             "locked": "42.3.8"
         },
         "org.springframework.boot:spring-boot-starter-jdbc": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:elasticsearch": {
             "locked": "1.18.3"

--- a/task/kafka/dependencies.lock
+++ b/task/kafka/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -42,13 +42,13 @@
             "locked": "2.17.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework:spring-web": {
             "locked": "5.3.30"
@@ -151,13 +151,13 @@
             "locked": "2.3-groovy-3.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:mockserver": {
             "locked": "1.18.3"
@@ -336,19 +336,19 @@
             "locked": "2.3-groovy-3.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
             "firstLevelTransitive": [
                 "com.netflix.conductor:conductor-test-util"
             ],
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:elasticsearch": {
             "firstLevelTransitive": [

--- a/test-util/dependencies.lock
+++ b/test-util/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -81,7 +81,7 @@
             "locked": "2.3-groovy-3.0"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:elasticsearch": {
             "locked": "1.18.3"
@@ -173,7 +173,7 @@
             "locked": "2.3-groovy-3.0"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.testcontainers:elasticsearch": {
             "locked": "1.18.3"
@@ -271,13 +271,13 @@
             "locked": "2.3-groovy-3.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework:spring-web": {
             "locked": "5.3.30"
@@ -378,13 +378,13 @@
             "locked": "2.3-groovy-3.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-validation": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework:spring-web": {
             "locked": "5.3.30"

--- a/workflow-event-listener/dependencies.lock
+++ b/workflow-event-listener/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.springframework.boot:spring-boot-configuration-processor": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "compileClasspath": {
@@ -27,10 +27,10 @@
             "locked": "2.17.2"
         },
         "org.springframework.boot:spring-boot-starter": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "runtimeClasspath": {
@@ -97,13 +97,13 @@
             "locked": "2.3-groovy-3.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     },
     "testRuntimeClasspath": {
@@ -147,13 +147,13 @@
             "locked": "2.3-groovy-3.0"
         },
         "org.springframework.boot:spring-boot-starter-log4j2": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-test": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "2.7.16"
+            "locked": "2.7.18"
         }
     }
 }


### PR DESCRIPTION
Jars are upgraded as per listed in the below JIRA. For tomcat jar its required to upgrade spring-boot. Hence spring-boot jar is upgraded in all the places its referenced.

https://jira-eng-sjc11.cisco.com/jira/browse/MINERVA-2937


Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
